### PR TITLE
Add PR build check and pin deploy CI to Node 22

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
           cache-dependency-path: ${{ env.BUILD_PATH }}/${{ steps.detect-package-manager.outputs.lockfile }}
       - name: Setup Pages

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,25 @@
+name: PR Build Check
+
+on:
+  pull_request:
+    branches: ["master"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+      - name: Build with Astro
+        run: npx astro build


### PR DESCRIPTION
## Summary
- New `.github/workflows/pr-build.yml` workflow runs `npm ci --legacy-peer-deps` and `astro build` on every PR targeting `master`. The existing deploy workflow only fires on push to master, which is why the Node 20 / Astro 6 incompatibility in #30 wasn't caught until after merge.
- Re-pins the deploy workflow's `node-version` to `"22"` so master deploys don't break on Astro 6's `>=22.12.0` requirement.

## Notes for reviewers
- `--legacy-peer-deps` is needed because `solid-devtools` (an optional peer of `@astrojs/solid-js` v6) hasn't tagged Vite 8 support yet — same flag used locally.
- The PR build workflow only installs and builds, no deploy steps, so it has minimal permissions (`contents: read`).

## Test plan
- [x] On this PR, confirm the new "PR Build Check / Build" job runs and passes.
- [ ] After merge, confirm the deploy workflow still runs and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)