### PR TITLE
Add PR build check CI and fix Now card copy

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
           cache-dependency-path: ${{ env.BUILD_PATH }}/${{ steps.detect-package-manager.outputs.lockfile }}
       - name: Setup Pages

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,25 @@
+name: PR Build Check
+
+on:
+  pull_request:
+    branches: ["master"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+      - name: Build with Astro
+        run: npx astro build

--- a/src/components/Now.astro
+++ b/src/components/Now.astro
@@ -8,5 +8,5 @@ import Pulse from "./Pulse.astro";
     <h2>Now</h2>
     <Pulse />
   </div>
-  <p class="text-xs">Now at Palo Alto Networks, working on Chronosphere's alerting platform</p>
+  <p class="text-xs">Working on the alerting platform at Chronosphere, now part of Palo Alto Networks.</p>
 </Card>


### PR DESCRIPTION
## What changed

- **CI:** Added a build check that runs on pull requests, and pinned the deploy workflow to Node 22.
- **Copy:** Rephrased the "Now" card paragraph. The card heading is already "Now" (next to a pulsing green status dot), so a paragraph that also started with "Now" read awkwardly and repetitively. It now reads as a standalone sentence: _"Working on the alerting platform at Chronosphere, now part of Palo Alto Networks."_

## Why

The PR build check gives early feedback that changes compile before merging to `master`. The copy fix removes the duplicated "Now" wording so the status card reads cleanly.

## Reviewer notes

The copy change is purely presentational — see `src/components/Now.astro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)